### PR TITLE
Purified function signatures in ONN Scorers

### DIFF
--- a/one_nearest_neighbor.py
+++ b/one_nearest_neighbor.py
@@ -93,9 +93,7 @@ class NaiveOneNearestNeighborScorer(BaseScorer):
 class AlexNetOneNearestNeighborScorer(NaiveOneNearestNeighborScorer):
     def __int__(self, images_real, images_fake, session: BaseSession, dir_for_list, alexnet=None):
         NaiveOneNearestNeighborScorer.__init__(self, images_real, images_fake)
-        self.dir_for_list = dir_for_list
         self.session = session
-        self._make_dir_for_list()
         if alexnet is None:
             self._alexnet = None  # declare field in constructor to avoid warnings
             self._set_default_alexnet()
@@ -105,13 +103,6 @@ class AlexNetOneNearestNeighborScorer(NaiveOneNearestNeighborScorer):
 
     def _tf_init(self):
         self.session.run(tf.global_variables_initializer())
-
-    def _make_dir_for_list(self):
-        try:
-            os.makedirs(self.dir_for_list)
-        except FileExistsError as e:
-            print(e)
-            print("abort making dir")
 
     def _set_latent(self):
         # equivalent to setting the initial values for self._latent

--- a/one_nearest_neighbor.py
+++ b/one_nearest_neighbor.py
@@ -14,6 +14,7 @@ Dataset = tf.data.Dataset
 
 class NaiveOneNearestNeighborScorer(BaseScorer):
     def __init__(self, images_real, images_fake):
+        super(NaiveOneNearestNeighborScorer, self).__init__()
         self._images0 = images_fake
         self._images1 = images_real
         self._latent = None

--- a/one_nearest_neighbor.py
+++ b/one_nearest_neighbor.py
@@ -103,6 +103,10 @@ class AlexNetOneNearestNeighborScorer(NaiveOneNearestNeighborScorer):
             self._set_default_alexnet()
         else:
             self._alexnet = alexnet
+        self._tf_init()
+
+    def _tf_init(self):
+        self.session.run(tf.global_variables_initializer())
 
     def _make_dir_for_list(self):
         try:

--- a/one_nearest_neighbor.py
+++ b/one_nearest_neighbor.py
@@ -39,7 +39,7 @@ class NaiveOneNearestNeighborScorer(BaseScorer):
             raise TypeError("unsupported input format {}".format(type(images)))
 
     @staticmethod
-    def _flatten(cls, array):
+    def _flatten(array):
         return np.reshape(array, [len(array), -1])
 
     def _set_latent(self):

--- a/one_nearest_neighbor.py
+++ b/one_nearest_neighbor.py
@@ -23,24 +23,28 @@ class NaiveOneNearestNeighborScorer(BaseScorer):
         self._score = None
 
     @classmethod
-    def _convert_latent(cls, images):
+    def _convert_to_array(cls, images):
         if isinstance(images, np.ndarray):
-            return np.reshape(images, [len(images), -1])
+            return images
         elif isinstance(images, (list, tuple)):
             try:
                 if isinstance(images[0], Image):
-                    return np.stack(np.reshape(np.asarray(img), -1) for img in images)
+                    return np.stack(np.asarray(img) for img in images)
                 else:
-                    return np.stack(np.reshape(img, -1) for img in images)
+                    return np.stack(images)
             except IndexError as e:
                 print("check that `images` of {} is not empty".format(cls.__name__))
                 raise e
         else:
             raise TypeError("unsupported input format {}".format(type(images)))
 
+    @staticmethod
+    def _flatten(cls, array):
+        return np.reshape(array, [len(array), -1])
+
     def _set_latent(self):
-        latent0 = self._convert_latent(self._images0)
-        latent1 = self._convert_latent(self._images1)
+        latent0 = self._flatten(self._convert_to_array(self._images0))
+        latent1 = self._flatten(self._convert_to_array(self._images1))
         if latent0.shape != latent1.shape:
             raise ValueError("real and fake latents differ in shape {} != {}".format(latent0.shape, latent1.shape))
         self._latent = np.concatenate([latent0, latent1])

--- a/one_nearest_neighbor.py
+++ b/one_nearest_neighbor.py
@@ -1,10 +1,7 @@
-import os
 import tensorflow as tf
 import numpy as np
 from cnn.alexnet import AlexNet
 from tensorflow.python.client.session import BaseSession
-from utils import make_list, get_init_op
-from datagenerator import ImageDataGenerator
 from scipy.spatial.distance import cdist
 from PIL.Image import Image
 from base import BaseScorer

--- a/one_nearest_neighbor.py
+++ b/one_nearest_neighbor.py
@@ -2,13 +2,14 @@ import os
 import tensorflow as tf
 import numpy as np
 from cnn.alexnet import AlexNet
-from tensorflow.contrib.data import Iterator
 from tensorflow.python.client.session import BaseSession
 from utils import make_list, get_init_op
 from datagenerator import ImageDataGenerator
 from scipy.spatial.distance import cdist
 from PIL.Image import Image
 from base import BaseScorer
+Iterator = tf.data.Iterator
+Dataset = tf.data.Dataset
 
 
 class NaiveOneNearestNeighborScorer(BaseScorer):

--- a/one_nearest_neighbor.py
+++ b/one_nearest_neighbor.py
@@ -12,8 +12,7 @@ from base import BaseScorer
 
 
 class NaiveOneNearestNeighborScorer(BaseScorer):
-    def __init__(self, images_real, images_fake, dir_for_list):
-        self.dir_for_list = dir_for_list
+    def __init__(self, images_real, images_fake):
         self._images0 = images_fake
         self._images1 = images_real
         self._latent = None
@@ -88,8 +87,10 @@ class NaiveOneNearestNeighborScorer(BaseScorer):
 
 
 class AlexNetOneNearestNeighborScorer(NaiveOneNearestNeighborScorer):
-    def __int__(self, folder_real, folder_generated, session: BaseSession, dir_for_list, alexnet=None):
-        NaiveOneNearestNeighborScorer.__init__(self, folder_real, folder_generated, session, dir_for_list)
+    def __int__(self, images_real, images_fake, session: BaseSession, dir_for_list, alexnet=None):
+        NaiveOneNearestNeighborScorer.__init__(self, images_real, images_fake)
+        self.dir_for_list = dir_for_list
+        self.session = session
         self._make_dir_for_list()
         if alexnet is None:
             self._alexnet = None  # declare field in constructor to avoid warnings


### PR DESCRIPTION
`OneNearsetNeighborScorer` now only needs `images_real` and `images_fake` to be passed to its Constructor
`AlexNetNearsetNeighborScorer`requries an additional `session` and an optional `alexnet`